### PR TITLE
Fix missing liblz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 MAINTAINER Lawrence-Tang <tangzongsheng@gmail.com>
 
-RUN apt-get update; apt-get install -y openjdk-8-jdk bc python rsync \
+RUN apt-get update; apt-get install -y  liblz4-tool openjdk-8-jdk bc python rsync \
     git-core gnupg flex bison gperf build-essential \
     zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 \
     lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache \


### PR DESCRIPTION
"liblz not found" error occured when building kernel, 
add liblz4-tool for kernel building process